### PR TITLE
keep the product list with a default size while loading each images

### DIFF
--- a/src/components/ListOfProducts.vue
+++ b/src/components/ListOfProducts.vue
@@ -1,7 +1,9 @@
 <template>
   <ul class="listOfProducts">
     <li v-for="(product, index) in products" :key="index" class="product">
-      <img :src="product.image" alt="">
+      <div class="image-container">
+        <img :src="product.image" alt="">
+      </div>
       <router-link to="/product-details">
         <h2 class="product-name"
             @click="addCurrentProduct(product)">
@@ -90,5 +92,7 @@ export default {
     margin-bottom: .5em;
   }
 
+  .image-container {
+      min-height: 252px;
+  }
 </style>
-


### PR DESCRIPTION
#6 While an image is loading the product list doesn't keep the same size of one with an image loaded, and if there's not loaded image then it shorten than the others with images loaded.

The image below show the issue.

[http://prntscr.com/l9jp27](url) 